### PR TITLE
feat: add configuration to enable webResponse in newRelic middleware

### DIFF
--- a/chi/v4/config.go
+++ b/chi/v4/config.go
@@ -15,6 +15,7 @@ const (
 	MiddlewareRequestIDEnabled = "gi.chi.middleware.requestid.enabled"
 	MiddlewareNewTID           = "gi.chi.middleware.newtid.enabled"
 	MiddlewareNewRelic         = "gi.chi.middleware.newrelic.enabled"
+	NewRelicWebResponseEnabled = "gi.chi.middleware.newrelic.webResponseEnabled"
 )
 
 func init() {
@@ -29,6 +30,7 @@ func init() {
 	giconfig.Add(MiddlewareRequestIDEnabled, true, "enable/disable request id middleware")
 	giconfig.Add(MiddlewareNewTID, true, "enable/disable new tid middleware")
 	giconfig.Add(MiddlewareNewRelic, false, "enable/disable new relic middleware")
+	giconfig.Add(NewRelicWebResponseEnabled, true, "enable/disable WebResponse from middleware")
 }
 
 func GetStatusRoute() string {
@@ -58,4 +60,8 @@ func GetMiddlewareNewTidEnabled() bool {
 
 func GetMiddlewareNewRelicEnabled() bool {
 	return giconfig.Bool(MiddlewareNewRelic)
+}
+
+func GetNewRelicWebResponseEnabled() bool {
+	return giconfig.Bool(NewRelicWebResponseEnabled)
 }

--- a/chi/v4/middleware.go
+++ b/chi/v4/middleware.go
@@ -127,7 +127,10 @@ func NewNewRelicMiddleware(next http.Handler) http.Handler {
 		defer txn.End()
 
 		txn.SetWebRequestHTTP(r)
-		w = txn.SetWebResponse(w)
+
+		if GetNewRelicWebResponseEnabled() {
+			w = txn.SetWebResponse(w)
+		}
 
 		txn.AddAttribute("request.url", fmt.Sprintf("http://%s%s", r.Host, url))
 


### PR DESCRIPTION
Adding config that allow to disable automatic error marking in newRelic middleware to prevent duplication of errors when using NoticeError
@modest0 @werickvieira @ropumar @jpfaria @rfabricante 