### PR TITLE
feat(log): print & printf support

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -19,6 +19,10 @@ type Logger interface {
 
 	Info(args ...interface{})
 
+	Printf(format string, args ...interface{})
+
+	Print(args ...interface{})
+
 	Warnf(format string, args ...interface{})
 
 	Warn(args ...interface{})

--- a/log/logrus/v1/logger.go
+++ b/log/logrus/v1/logger.go
@@ -173,6 +173,10 @@ func (l *logger) Info(args ...interface{}) {
 	l.logger.Info(args...)
 }
 
+func (l *logger) Print(args ...interface{}) {
+	l.logger.Print(args...)
+}
+
 func (l *logger) Warn(args ...interface{}) {
 	l.logger.Warn(args...)
 }
@@ -205,6 +209,10 @@ func (l *logger) Debugf(format string, args ...interface{}) {
 
 func (l *logger) Infof(format string, args ...interface{}) {
 	l.logger.Infof(format, args...)
+}
+
+func (l *logger) Printf(format string, args ...interface{}) {
+	l.logger.Printf(format, args...)
 }
 
 func (l *logger) Warnf(format string, args ...interface{}) {
@@ -278,6 +286,10 @@ func (l *logEntry) Info(args ...interface{}) {
 	l.entry.Info(args...)
 }
 
+func (l *logEntry) Print(args ...interface{}) {
+	l.entry.Print(args...)
+}
+
 func (l *logEntry) Warn(args ...interface{}) {
 	l.entry.Warn(args...)
 }
@@ -314,6 +326,10 @@ func (l *logEntry) Debugf(format string, args ...interface{}) {
 
 func (l *logEntry) Infof(format string, args ...interface{}) {
 	l.entry.Infof(format, args...)
+}
+
+func (l *logEntry) Printf(format string, args ...interface{}) {
+	l.entry.Printf(format, args...)
 }
 
 func (l *logEntry) Warnf(format string, args ...interface{}) {

--- a/log/wrapper.go
+++ b/log/wrapper.go
@@ -24,6 +24,14 @@ func Info(args ...interface{}) {
 	l.Info(args...)
 }
 
+func Printf(format string, args ...interface{}) {
+	l.Printf(format, args...)
+}
+
+func Print(args ...interface{}) {
+	l.Print(args...)
+}
+
 func Warnf(format string, args ...interface{}) {
 	l.Warnf(format, args...)
 }

--- a/log/zap/v1/logger.go
+++ b/log/zap/v1/logger.go
@@ -133,6 +133,10 @@ func (l *zapLogger) Info(args ...interface{}) {
 	l.sugaredLogger.Info(args...)
 }
 
+func (l *zapLogger) Print(args ...interface{}) {
+	l.sugaredLogger.Info(args...)
+}
+
 func (l *zapLogger) Warn(args ...interface{}) {
 	l.sugaredLogger.Warn(args...)
 }
@@ -171,6 +175,10 @@ func (l *zapLogger) Debugf(format string, args ...interface{}) {
 }
 
 func (l *zapLogger) Infof(format string, args ...interface{}) {
+	l.sugaredLogger.Infof(format, args...)
+}
+
+func (l *zapLogger) Printf(format string, args ...interface{}) {
 	l.sugaredLogger.Infof(format, args...)
 }
 

--- a/log/zerolog/v1/logger.go
+++ b/log/zerolog/v1/logger.go
@@ -130,6 +130,14 @@ func (l *logger) Infof(format string, args ...interface{}) {
 	l.logger.Info().Msgf(format, args...)
 }
 
+func (l *logger) Print(args ...interface{}) {
+	l.logger.Print(args...)
+}
+
+func (l *logger) Printf(format string, args ...interface{}) {
+	l.logger.Printf(format, args...)
+}
+
 func (l *logger) Info(args ...interface{}) {
 	format := bytes.NewBufferString("")
 	for _ = range args {


### PR DESCRIPTION
In order to embrace fx [Printer](https://pkg.go.dev/go.uber.org/fx#Printer) interface, those log methods were implemented, besides Print isn't required though.